### PR TITLE
fix: Added User display message to active users on server

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -16,5 +16,6 @@ io.on('connect', socket => {
 
     socket.on('setUsername', username => {
       socket.username = username; // Set the username for the socket
+      io.emit('bye-bye', { message: `${socket.username} has joined the chat.` });
     });
   });


### PR DESCRIPTION
fixes #24 

**Screenshot**
![image](https://github.com/achhayapathak/termtalk/assets/149759338/f21a1ca1-6972-41f9-9815-7bef5075b523)

**Description**
The line added broadcasts a message to all users when someone new joins the chat. It lets everyone know the username of the new member who has just joined the chat server.